### PR TITLE
refactor(tickManager): replace CSS animations with WAAPI

### DIFF
--- a/style.css
+++ b/style.css
@@ -159,9 +159,6 @@ body {
     opacity: 1;
 }
 
-@keyframes fadeOut {
-    to { opacity: 0; }
-}
 
 .tick {
     position: absolute;
@@ -173,14 +170,10 @@ body {
     z-index: 7;
 }
 
-.tick:not(.inactive) {
-    animation: fadeOut var(--fade-out-duration) linear var(--tick-duration) forwards;
-}
 
 .tick.inactive {
     visibility: hidden;
     pointer-events: none;
-    animation: none;
     opacity: 0;
 }
 /* Timing window-based colors for ticks */


### PR DESCRIPTION
- Refactor TickImpl to use Web Animations API for tick fade-out animations
- Add _currentAnimation property to manage animation state
- Remove CSS @keyframes and animation properties now handled by WAAPI
- Fix lint error by removing empty .tick:not(.inactive) ruleset
- Improve animation control and cleanup in setActive, resetActive, and setInactive methods