### PR TITLE
Add custom timing window settings

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -198,5 +198,21 @@
         "description": "only check this if you are using the overlay in the ingame overlay injector",
         "options": [],
         "value": false
+    },
+    {
+        "uniqueID": "useCustomTimingWindows",
+        "type": "checkbox",
+        "title": "Use Custom Timing Windows",
+        "description": "enable to override automatic timing window calculation",
+        "options": [],
+        "value": false
+    },
+    {
+        "uniqueID": "customTimingWindows",
+        "type": "text",
+        "title": "Custom Timing Windows",
+        "description": "comma separated list of 5 timing windows",
+        "options": [],
+        "value": "16.5,64,97,127,151"
     }
 ]

--- a/src/calculation/timingWindows.ts
+++ b/src/calculation/timingWindows.ts
@@ -6,7 +6,7 @@ const calculateOsuWindows = (od: number, mods: string): Map<string, number> => {
         windows.set("100", 140 - 8 * modifiedOd);
         windows.set("50", 200 - 10 * modifiedOd);
     } else if (mods.includes("HR")) {
-        const modifiedOd = Math.min(od * 1.4, 10)
+        const modifiedOd = Math.min(od * 1.4, 10);
         windows.set("300", 50 - 3 * modifiedOd);
         windows.set("100", 140 - 8 * modifiedOd);
         windows.set("50", 200 - 10 * modifiedOd);
@@ -29,7 +29,7 @@ const calculateTaikoWindows = (od: number, mods: string): Map<string, number> =>
         } else {
             windows.set("100", 110 - 6 * modifiedOd);
             windows.set("50", 120 - 5 * modifiedOd);
-        };
+        }
     } else if (mods.includes("HR")) {
         const modifiedOd = Math.min(od * 1.4, 10);
         windows.set("300", 50 - 3 * modifiedOd);
@@ -39,7 +39,7 @@ const calculateTaikoWindows = (od: number, mods: string): Map<string, number> =>
         } else {
             windows.set("100", 110 - 6 * modifiedOd);
             windows.set("50", 120 - 5 * modifiedOd);
-        };
+        }
     } else {
         windows.set("300", 50 - 3 * od);
         if (od >= 5) {
@@ -48,7 +48,7 @@ const calculateTaikoWindows = (od: number, mods: string): Map<string, number> =>
         } else {
             windows.set("100", 110 - 6 * od);
             windows.set("50", 120 - 5 * od);
-        };
+        }
     }
     return windows;
 };
@@ -74,14 +74,39 @@ const calculateManiaWindows = (od: number, mods: string): Map<string, number> =>
         windows.set("300", 64 - 3 * od);
         windows.set("200", 97 - 3 * od);
         windows.set("100", 127 - 3 * od);
-        windows.set("50", 151 - 3 * od);        
+        windows.set("50", 151 - 3 * od);
     }
     return windows;
 };
 
-export const calculateTimingWindows = (gamemode: string, od: number, mods: string): Map<string, number> => {
+export const calculateTimingWindows = (
+    gamemode: string,
+    od: number,
+    mods: string,
+    customTimingWindows?: string,
+): Map<string, number> => {
+    if (customTimingWindows) {
+        const values = customTimingWindows.split(",").map((v) => Number.parseFloat(v.trim()));
+        const windows = new Map<string, number>();
+        if (gamemode === "mania") {
+            const grades = ["300g", "300", "200", "100", "50"];
+            grades.forEach((grade, idx) => {
+                if (idx < values.length) {
+                    windows.set(grade, values[idx]);
+                }
+            });
+        } else {
+            const grades = ["300", "100", "50"];
+            grades.forEach((grade, idx) => {
+                if (idx < values.length) {
+                    windows.set(grade, values[idx]);
+                }
+            });
+        }
+        return windows;
+    }
+
     // Calculate timing windows based on gamemode
-    // pass in od and mods, and get back a map of timing windows
     switch (gamemode) {
         case "osu":
             return calculateOsuWindows(od, mods);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,7 @@
 import WebSocketManager from "./sockets/socket";
 import type { CommandData, WEBSOCKET_V2, WEBSOCKET_V2_PRECISE } from "./sockets/types";
 import { settings, updateSettings, getSettings } from "./sockets/settings";
-import {
-    updateTimingWindowElements,
-    setHidden,
-    setVisible,
-    getElement,
-} from "./rendering/elements";
+import { updateTimingWindowElements, setHidden, setVisible, getElement } from "./rendering/elements";
 import { calculateTimingWindows } from "./calculation/timingWindows";
 import { renderTicksOnLoad } from "./rendering/ticks"; // Removed updateTicks
 import { updateArrow } from "./rendering/arrow";
@@ -71,7 +66,11 @@ if (settings.showSD) {
 }
 
 // Handle game state and menu updates
-const apiV2Filters = ["state", { field: "play", keys: ['mode', 'mods'] }, { field: "beatmap", keys: ['mode', 'stats', 'time'] }];
+const apiV2Filters = [
+    "state",
+    { field: "play", keys: ["mode", "mods"] },
+    { field: "beatmap", keys: ["mode", "stats", "time"] },
+];
 wsManager.api_v2((data: WEBSOCKET_V2) => {
     if (cache.state !== data.state.name) {
         cache.state = data.state.name;
@@ -87,10 +86,10 @@ wsManager.api_v2((data: WEBSOCKET_V2) => {
                 cache.mods = data.play.mods.name;
             }
 
-            
             cache.rate = data.play.mods.rate;
             cache.firstObjectTime = data.beatmap.time.firstObject;
-            cache.timingWindows = calculateTimingWindows(cache.mode, cache.od, cache.mods);
+            const custom = settings.useCustomTimingWindows ? settings.customTimingWindows : undefined;
+            cache.timingWindows = calculateTimingWindows(cache.mode, cache.od, cache.mods, custom);
             updateTimingWindowElements();
             setVisible();
             cache.isReset = false;

--- a/src/sockets/settings.ts
+++ b/src/sockets/settings.ts
@@ -30,6 +30,8 @@ export const settings: Settings = {
     color0: "#000000",
     showSD: false,
     disableHardwareAcceleration: false,
+    useCustomTimingWindows: false,
+    customTimingWindows: "16.5,64,97,127,151",
 };
 // define root element
 const root = typeof document !== "undefined" ? document.documentElement : { style: { setProperty: () => {} } };

--- a/src/sockets/types.d.ts
+++ b/src/sockets/types.d.ts
@@ -73,6 +73,8 @@ export interface Settings {
     color0: string;
     showSD: boolean;
     disableHardwareAcceleration: boolean;
+    useCustomTimingWindows: boolean;
+    customTimingWindows: string;
 }
 
 export interface CommandData {


### PR DESCRIPTION
## Summary
- allow overriding default timing windows
- add `useCustomTimingWindows` and `customTimingWindows` settings
- apply custom timing windows in calculation

## Testing
- `pnpm run lint`
- `pnpm run format`


------
https://chatgpt.com/codex/tasks/task_e_684f3f34312c832ab25d27b65dfd1155