### PR TITLE
Handle black as transparent

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -3,7 +3,7 @@
         "uniqueID": "doesNothing",
         "type": "textarea",
         "title": "Notes:",
-        "description": "color selection only works in dashboard, not ingame overlay manager (TOSU ISSUE)   \n\nsetting names should be clear as to what they do and how they are implemented relative to another setting/element   \n\nnumeric settings for dimensions and timings (px and ms) do not have any limits, but take note of the following:   \n\n        - adjust your metadata.txt and obs browser source dimension settings when changing (px) values   \n\n        - percentage values should be limited from 0 to 100   \n\n        - opacity values should be limited from 0 to 1   \n\n        - changing the timings to be higher can greatly detriment performance as there will be more elements to render.\n\nhave fun!",
+        "description": "color selection only works in dashboard, not ingame overlay manager (TOSU ISSUE)   \n\nsetting names should be clear as to what they do and how they are implemented relative to another setting/element   \n\nnumeric settings for dimensions and timings (px and ms) do not have any limits, but take note of the following:   \n\n        - adjust your metadata.txt and obs browser source dimension settings when changing (px) values   \n\n        - percentage values should be limited from 0 to 100   \n\n        - opacity values should be limited from 0 to 1   \n\n        - changing the timings to be higher can greatly detriment performance as there will be more elements to render.   \n\n        - using the color value #000000 will render that element transparent.\n\nhave fun!",
         "options": [],
         "value": "feel free to adjust this text. it does nothing."
     },

--- a/src/sockets/settings.ts
+++ b/src/sockets/settings.ts
@@ -9,7 +9,7 @@ export const settings: Settings = {
     TimingWindowOpacity: 0,
     barHeight: 0,
     barWidth: 0,
-    colorBar: "#000000",
+    colorBar: "transparent",
     tickWidth: 0,
     tickHeight: 0,
     tickDuration: 0,
@@ -17,17 +17,17 @@ export const settings: Settings = {
     fadeOutDuration: 0,
     arrowSize: 0,
     perfectArrowThreshold: 0,
-    colorArrowEarly: "#000000",
-    colorArrowLate: "#000000",
-    colorArrowPerfect: "#000000",
+    colorArrowEarly: "transparent",
+    colorArrowLate: "transparent",
+    colorArrowPerfect: "transparent",
     timingWindowHeight: 0,
     isRounded: 0,
-    color300g: "#000000",
-    color300: "#000000",
-    color200: "#000000",
-    color100: "#000000",
-    color50: "#000000",
-    color0: "#000000",
+    color300g: "transparent",
+    color300: "transparent",
+    color200: "transparent",
+    color100: "transparent",
+    color50: "transparent",
+    color0: "transparent",
     showSD: false,
     disableHardwareAcceleration: false,
     useCustomTimingWindows: false,
@@ -131,18 +131,19 @@ const updateCSSLayout = () => {
 };
 
 const updateCSSColors = () => {
+    const sanitize = (color: string) => (color.toLowerCase() === "#000000" ? "transparent" : color);
     root.style.setProperty("--timing-windows-opacity", String(settings.TimingWindowOpacity));
     root.style.setProperty("--tick-opacity", String(settings.tickOpacity));
-    root.style.setProperty("--color-300g", settings.color300g);
-    root.style.setProperty("--color-300", settings.color300);
-    root.style.setProperty("--color-200", settings.color200);
-    root.style.setProperty("--color-100", settings.color100);
-    root.style.setProperty("--color-50", settings.color50);
-    root.style.setProperty("--color-0", settings.color0);
-    root.style.setProperty("--arrow-early", settings.colorArrowEarly);
-    root.style.setProperty("--arrow-late", settings.colorArrowLate);
-    root.style.setProperty("--arrow-perfect", settings.colorArrowPerfect);
-    root.style.setProperty("--bar-color", settings.colorBar);
+    root.style.setProperty("--color-300g", sanitize(settings.color300g));
+    root.style.setProperty("--color-300", sanitize(settings.color300));
+    root.style.setProperty("--color-200", sanitize(settings.color200));
+    root.style.setProperty("--color-100", sanitize(settings.color100));
+    root.style.setProperty("--color-50", sanitize(settings.color50));
+    root.style.setProperty("--color-0", sanitize(settings.color0));
+    root.style.setProperty("--arrow-early", sanitize(settings.colorArrowEarly));
+    root.style.setProperty("--arrow-late", sanitize(settings.colorArrowLate));
+    root.style.setProperty("--arrow-perfect", sanitize(settings.colorArrowPerfect));
+    root.style.setProperty("--bar-color", sanitize(settings.colorBar));
 };
 
 export const updateVisibility = () => {


### PR DESCRIPTION
## Summary
- allow `#000000` to become transparent
- document the behavior in `settings.json`

## Testing
- `npm run lint`
- `npm run format`
- `npm run build:ci`


------
https://chatgpt.com/codex/tasks/task_e_684f4349b7f8832a84c5f6bb0438323e