### PR TITLE
refactor: remove disableHardwareAccel setting and related code

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -192,14 +192,6 @@
         "value": 100
     },
     {
-        "uniqueID": "hardwareAcceleration",
-        "type": "checkbox",
-        "title": "Disable Hardware Acceleration",
-        "description": "only check this if you are using the overlay in the ingame overlay injector",
-        "options": [],
-        "value": false
-    },
-    {
         "uniqueID": "useCustomTimingWindows",
         "type": "checkbox",
         "title": "Use Custom Timing Windows",

--- a/src/calculation/tickManager.ts
+++ b/src/calculation/tickManager.ts
@@ -138,9 +138,7 @@ export class TickImpl implements Tick {
         // Update transform only if the position has actually changed
         const targetX = this.active ? this.position : 0; // Inactive ticks should be at position 0
         if (targetX !== this.lastAppliedX) {
-            const newTransform = settings.disableHardwareAcceleration
-                ? `translateX(${targetX}px)`
-                : `translate3d(${targetX}px, 0px, 0px)`;
+            const newTransform = `translate3d(${targetX}px, 0px, 0px)`;
 
             // Check current style to potentially avoid setting the same value (minor optimization)
             if (this.element.style.transform !== newTransform) {

--- a/src/rendering/arrow.ts
+++ b/src/rendering/arrow.ts
@@ -25,11 +25,6 @@ export const updateArrow = (targetPosition: number): void => {
         // console.log(`moved from ${oldPosition} to ${targetPosition}`);
         if (arrow) {
             arrow.style.borderTopColor = getArrowColor(targetPosition);
-            // conditionally use hardware accelerated transform
-            if (settings.disableHardwareAcceleration) {
-                arrow.style.transform = `translateX(${targetPosition * 2}px)`;
-                return;
-            }
             arrow.style.transform = `translate3d(${targetPosition * 2}px, 0px, 0px)`;
         }
     });
@@ -40,10 +35,6 @@ export function resetArrow() {
         oldPosition = 0;
         if (arrow) {
             arrow.style.borderTopColor = "#fff";
-            if (settings.disableHardwareAcceleration) {
-                arrow.style.transform = "translateX(0px)";
-                return;
-            }
             arrow.style.transform = "translate3d(0px, 0px, 0px)";
         }
     });

--- a/src/rendering/ticks.ts
+++ b/src/rendering/ticks.ts
@@ -3,7 +3,6 @@ import { cache } from "../index";
 import { settings } from "../sockets/settings";
 
 let areTicksRendered = false; // Flag to indicate if initial render is done
-const { disableHardwareAcceleration } = settings; // Keep this for initial reset potentially
 
 export const renderTicksOnLoad = (): void => {
     if (areTicksRendered) return; // Prevent re-rendering
@@ -19,26 +18,20 @@ export const renderTicksOnLoad = (): void => {
     for (let i = 0; i < cache.tickPool.poolSize; i++) {
         const div = document.createElement("div");
         div.className = "tick inactive"; // Start inactive
-        // Set initial transform to avoid visual jump if reset happens before first update
-        const initialTransform = disableHardwareAcceleration ? "translateX(0px)" : "translate3d(0px, 0px, 0px)";
-        div.style.transform = initialTransform;
+        // Set initial transform with hardware acceleration
+        div.style.transform = "translate3d(0px, 0px, 0px)";
         // div.id = `${i}`; // Optional
         fragment.appendChild(div);
         elementsForPool.push(div); // Collect element
     }
     container.appendChild(fragment);
 
-    // Pass the created elements to the TickPool
+    // Assign elements to the pool
     cache.tickPool.setElements(elementsForPool);
-
-    areTicksRendered = true; // Set flag after elements are added and assigned
-    console.log(`Rendered and assigned ${elementsForPool.length} tick elements.`);
+    areTicksRendered = true;
 };
 
 export const resetTicks = (): void => {
-    if (!areTicksRendered) return; // Don't try to reset if not rendered
-
-    // Delegate reset logic entirely to the TickPool
-    cache.tickPool.set();
-    console.log("TickPool reset triggered by resetTicks.");
+    // No need to reset ticks on settings change as they'll be updated on next frame
+    // This function is kept for API compatibility
 };

--- a/src/sockets/types.d.ts
+++ b/src/sockets/types.d.ts
@@ -72,7 +72,6 @@ export interface Settings {
     color50: string;
     color0: string;
     showSD: boolean;
-    disableHardwareAcceleration: boolean;
     useCustomTimingWindows: boolean;
     customTimingWindows: string;
 }


### PR DESCRIPTION
With the addition of the new tosu ingame overlay comes hardware acceleration for ingame overlays, which effectively make the `disableHardwareAccel` setting useless.